### PR TITLE
WIP: Avoid building custom Prometheus image

### DIFF
--- a/samples/compose/osx/docker-compose.yml
+++ b/samples/compose/osx/docker-compose.yml
@@ -62,14 +62,15 @@ services:
       - mongo:/data/db
 
   prometheus:
-    build: ./prometheus
+    image: prom/prometheus
     container_name: prometheus
     restart: unless-stopped
     ports:
       - '9090:9090'
     networks:
       - conveyor
-    # volumes:
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     #   - prometheus:/prometheus
 
   rabbitmq:

--- a/samples/compose/osx/prometheus/Dockerfile
+++ b/samples/compose/osx/prometheus/Dockerfile
@@ -1,3 +1,0 @@
-FROM prom/prometheus
-WORKDIR /app
-COPY ./prometheus.yml /etc/prometheus/prometheus.yml


### PR DESCRIPTION
Unless I'm missing something, there shouldn't be any need to build a new prometheus image, rather we can just mount the `prometheus.yml` into the running container.

Let me know if you feel this is cleaner & if you'd be open to merge it, in which case I can make the same change to the linux & windows `docker-compose.yml` files.