### PR TITLE
Added minimumlevel override to logging.

### DIFF
--- a/src/Convey.Logging/src/Convey.Logging/LoggerOptions.cs
+++ b/src/Convey.Logging/src/Convey.Logging/LoggerOptions.cs
@@ -10,6 +10,7 @@ namespace Convey.Logging
         public FileOptions File { get; set; }
         public ElkOptions Elk { get; set; }
         public SeqOptions Seq { get; set; }
+        public IDictionary<string, string> MinimumLevelOverrides { get; set; }
         public IEnumerable<string> ExcludePaths { get; set; }
         public IEnumerable<string> ExcludeProperties { get; set; }
         public IDictionary<string, object> Tags { get; set; }


### PR DESCRIPTION
Added very simple implementation of overriding default minimumlevels based on path.

For example you could override some microsoft default loggings but not all of them:
Simply put under logger section in appsettings.json:

"minimumLevelOverrides": {
      "Microsoft.EntityFrameworkCore": "Warning",
      "Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker": "Warning",
      "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Warning" 
    }

And now logger emits all logs that are under Warning level from those sources.

Easy to keep the console clean as it improves software performance aswell.