### PR TITLE
Added logginglevel control

### DIFF
--- a/src/Convey.Logging/src/Convey.Logging/LoggingService.cs
+++ b/src/Convey.Logging/src/Convey.Logging/LoggingService.cs
@@ -1,0 +1,9 @@
+﻿namespace Convey.Logging
+{
+    public interface ILoggingService
+    {
+        public void SetLoggingLevel(string logEventLevel)
+            => Extensions.LoggingLevelSwitch.MinimumLevel = Extensions.GetLogEventLevel(logEventLevel);
+    }
+    public class LoggingService : ILoggingService {}
+}


### PR DESCRIPTION
A small addition to serilog logging to control minimum level of logging.
You can inject `.MapLogLevelHandler()` to your endpoints section and it will add new endpoint with default route "/logging/level" which takes in query parameter level as level for which loglevel you want to use.
POST "~/logging/level?level=fatal" to filter out all but fatal type logging.