### PR TITLE
Pass a BuilderContext to logger configure action

### DIFF
--- a/src/Convey.Logging/src/Convey.Logging/Extensions.cs
+++ b/src/Convey.Logging/src/Convey.Logging/Extensions.cs
@@ -25,7 +25,7 @@ namespace Convey.Logging
         internal static LoggingLevelSwitch LoggingLevelSwitch = new LoggingLevelSwitch();
 
         public static IHostBuilder UseLogging(this IHostBuilder hostBuilder,
-            Action<LoggerConfiguration> configure = null, string loggerSectionName = LoggerSectionName,
+            Action<HostBuilderContext, LoggerConfiguration> configure = null, string loggerSectionName = LoggerSectionName,
             string appSectionName = AppSectionName)
             => hostBuilder
                 .ConfigureServices(services => services.AddSingleton<ILoggingService, LoggingService>())
@@ -45,11 +45,11 @@ namespace Convey.Logging
                 var appOptions = context.Configuration.GetOptions<AppOptions>(appSectionName);
 
                 MapOptions(loggerOptions, appOptions, loggerConfiguration, context.HostingEnvironment.EnvironmentName);
-                configure?.Invoke(loggerConfiguration);
+                configure?.Invoke(context, loggerConfiguration);
             });
 
         public static IWebHostBuilder UseLogging(this IWebHostBuilder webHostBuilder,
-            Action<LoggerConfiguration> configure = null, string loggerSectionName = LoggerSectionName,
+            Action<WebHostBuilderContext, LoggerConfiguration> configure = null, string loggerSectionName = LoggerSectionName,
             string appSectionName = AppSectionName)
             => webHostBuilder
                 .ConfigureServices(services => services.AddSingleton<ILoggingService, LoggingService>())
@@ -70,7 +70,7 @@ namespace Convey.Logging
 
                     MapOptions(loggerOptions, appOptions, loggerConfiguration,
                         context.HostingEnvironment.EnvironmentName);
-                    configure?.Invoke(loggerConfiguration);
+                    configure?.Invoke(context, loggerConfiguration);
                 });
 
         public static IEndpointConventionBuilder MapLogLevelHandler(this IEndpointRouteBuilder builder, 


### PR DESCRIPTION
By passing a BuilderContext to the logger configuration action it is possible to access the IConfiguration instance