### PR TITLE
Issue 79 RabbitMq JaegerPlugin Message Invalid cast exception

### DIFF
--- a/src/Convey.MessageBrokers.RabbitMQ/src/Convey.MessageBrokers.RabbitMQ/Plugins/RabbitMqPluginChain.cs
+++ b/src/Convey.MessageBrokers.RabbitMQ/src/Convey.MessageBrokers.RabbitMQ/Plugins/RabbitMqPluginChain.cs
@@ -5,6 +5,5 @@ namespace Convey.MessageBrokers.RabbitMQ.Plugins
     internal sealed class RabbitMqPluginChain
     {
         public Type PluginType { get; set; }
-        public IRabbitMqPlugin Plugin { get; set; }
     }
 }


### PR DESCRIPTION
Poprawia błąd: #79 
Geneza przyczyny błędu:
IRabbitMqPluginsRegistryAccessor _registry 
jest zarejestrowany jako singleton:  builder.Services.AddSingleton<IAccessTokenService, InMemoryAccessTokenService>();
Instancja listy zwracanej przez 
var chains = _registry.Get(); 
jest wspólna dla wszystkich wywołań ExecuteAsync.
Pod obciążeniem dochodzi do race condition 
w momencie ustawiania ((IRabbitMqPluginAccessor) current.Value).SetSuccessor( successor ).
To powoduje wywołanie delegatu successor 
dla typu niezgodnego z messagem przekazanym do ExecuteAsync.

Poprawka dodaje lokalną listę przechowującą pluginy co eliminuje wspomniany wyżej race condition.
