### PR TITLE
Replace FormatterServices.GetUninitializedObject

### DIFF
--- a/src/Convey.WebApi.CQRS/src/Convey.WebApi.CQRS/Middlewares/PublicContractsMiddleware.cs
+++ b/src/Convey.WebApi.CQRS/src/Convey.WebApi.CQRS/Middlewares/PublicContractsMiddleware.cs
@@ -1,16 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
 using Convey.CQRS.Commands;
 using Convey.CQRS.Events;
 using Convey.WebApi.Helpers;
 using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Convey.WebApi.CQRS.Middlewares
 {
@@ -44,7 +43,7 @@ namespace Convey.WebApi.CQRS.Middlewares
                 return;
             }
 
-            Load(attributeType); 
+            Load(attributeType);
         }
 
         public Task InvokeAsync(HttpContext context)
@@ -74,28 +73,28 @@ namespace Convey.WebApi.CQRS.Middlewares
 
             foreach (var command in contracts.Where(t => typeof(ICommand).IsAssignableFrom(t)))
             {
-                var instance = FormatterServices.GetUninitializedObject(command);
+                var instance = command.GetDefaultInstance();
                 var name = instance.GetType().Name;
+
                 if (Contracts.Commands.ContainsKey(name))
                 {
                     throw new InvalidOperationException($"Command: '{name}' already exists.");
                 }
 
-                instance.SetDefaultInstanceProperties();
                 Contracts.Commands[name] = instance;
             }
 
             foreach (var @event in contracts.Where(t => typeof(IEvent).IsAssignableFrom(t) &&
                                                         t != typeof(RejectedEvent)))
             {
-                var instance = FormatterServices.GetUninitializedObject(@event);
+                var instance = @event.GetDefaultInstance();
                 var name = instance.GetType().Name;
+
                 if (Contracts.Events.ContainsKey(name))
                 {
                     throw new InvalidOperationException($"Event: '{name}' already exists.");
                 }
 
-                instance.SetDefaultInstanceProperties();
                 Contracts.Events[name] = instance;
             }
 

--- a/src/Convey.WebApi/src/Convey.WebApi/EndpointsBuilder.cs
+++ b/src/Convey.WebApi/src/Convey.WebApi/EndpointsBuilder.cs
@@ -1,13 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Threading.Tasks;
 using Convey.WebApi.Helpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Convey.WebApi
 {
@@ -54,7 +53,7 @@ namespace Convey.WebApi
         {
             var builder = _routeBuilder.MapGet(path, ctx => BuildQueryContext(ctx, context));
             endpoint?.Invoke(builder);
-            ApplyAuthRolesAndPolicies(builder, auth,  roles, policies);
+            ApplyAuthRolesAndPolicies(builder, auth, roles, policies);
             AddEndpointDefinition<TRequest, TResult>(HttpMethods.Get, path);
 
             return this;
@@ -66,7 +65,7 @@ namespace Convey.WebApi
         {
             var builder = _routeBuilder.MapPost(path, ctx => context?.Invoke(ctx));
             endpoint?.Invoke(builder);
-            ApplyAuthRolesAndPolicies(builder, auth,  roles, policies);
+            ApplyAuthRolesAndPolicies(builder, auth, roles, policies);
             AddEndpointDefinition(HttpMethods.Post, path);
 
             return this;
@@ -79,7 +78,7 @@ namespace Convey.WebApi
         {
             var builder = _routeBuilder.MapPost(path, ctx => BuildRequestContext(ctx, context));
             endpoint?.Invoke(builder);
-            ApplyAuthRolesAndPolicies(builder, auth,  roles, policies);
+            ApplyAuthRolesAndPolicies(builder, auth, roles, policies);
             AddEndpointDefinition<T>(HttpMethods.Post, path);
 
             return this;
@@ -91,7 +90,7 @@ namespace Convey.WebApi
         {
             var builder = _routeBuilder.MapPut(path, ctx => context?.Invoke(ctx));
             endpoint?.Invoke(builder);
-            ApplyAuthRolesAndPolicies(builder, auth,  roles, policies);
+            ApplyAuthRolesAndPolicies(builder, auth, roles, policies);
             AddEndpointDefinition(HttpMethods.Put, path);
 
             return this;
@@ -104,7 +103,7 @@ namespace Convey.WebApi
         {
             var builder = _routeBuilder.MapPut(path, ctx => BuildRequestContext(ctx, context));
             endpoint?.Invoke(builder);
-            ApplyAuthRolesAndPolicies(builder, auth,  roles, policies);
+            ApplyAuthRolesAndPolicies(builder, auth, roles, policies);
             AddEndpointDefinition<T>(HttpMethods.Put, path);
 
             return this;
@@ -116,7 +115,7 @@ namespace Convey.WebApi
         {
             var builder = _routeBuilder.MapDelete(path, ctx => context?.Invoke(ctx));
             endpoint?.Invoke(builder);
-            ApplyAuthRolesAndPolicies(builder, auth,  roles, policies);
+            ApplyAuthRolesAndPolicies(builder, auth, roles, policies);
             AddEndpointDefinition(HttpMethods.Delete, path);
 
             return this;
@@ -129,7 +128,7 @@ namespace Convey.WebApi
         {
             var builder = _routeBuilder.MapDelete(path, ctx => BuildQueryContext(ctx, context));
             endpoint?.Invoke(builder);
-            ApplyAuthRolesAndPolicies(builder, auth,  roles, policies);
+            ApplyAuthRolesAndPolicies(builder, auth, roles, policies);
             AddEndpointDefinition<T>(HttpMethods.Delete, path);
 
             return this;
@@ -223,9 +222,7 @@ namespace Convey.WebApi
                         In = method == HttpMethods.Get ? "query" : "body",
                         Name = input?.Name,
                         Type = input,
-                        Example = input is null
-                            ? null
-                            : FormatterServices.GetUninitializedObject(input).SetDefaultInstanceProperties()
+                        Example = input?.GetDefaultInstance()
                     }
                 },
                 Responses = new List<WebApiEndpointResponse>
@@ -234,9 +231,7 @@ namespace Convey.WebApi
                     {
                         StatusCode = method == HttpMethods.Get ? 200 : 202,
                         Type = output,
-                        Example = output is null
-                            ? null
-                            : FormatterServices.GetUninitializedObject(output).SetDefaultInstanceProperties()
+                        Example = output?.GetDefaultInstance()
                     }
                 }
             });

--- a/src/Convey.WebApi/src/Convey.WebApi/Helpers/Extensions.cs
+++ b/src/Convey.WebApi/src/Convey.WebApi/Helpers/Extensions.cs
@@ -9,6 +9,23 @@ namespace Convey.WebApi.Helpers
 {
     public static class Extensions
     {
+        public static object GetDefaultInstance(this Type type)
+        {
+            if (type == typeof(string))
+            {
+                return string.Empty;
+            }
+
+            var defaultValueCache = new Dictionary<Type, object>();
+
+            if (TryGetDefaultValue(type, out var instance, defaultValueCache))
+            {
+                return instance;
+            }
+
+            return default;
+        }
+
         public static object SetDefaultInstanceProperties(this object instance)
             => SetDefaultInstanceProperties(instance, new Dictionary<Type, object>());
 
@@ -66,7 +83,7 @@ namespace Convey.WebApi.Helpers
                 return false;
             }
 
-            if (type.IsInterface)
+            if (type.IsInterface || type.IsAbstract)
             {
                 defaultValue = null;
 


### PR DESCRIPTION
FormatterServices.GetUninitializedObject gets error on interfaces (although the error says "Cannot create an abstract class." 🤨 )

I've refactored creating default instance (as example) in a bit more controlled way.