### PR TITLE
Log exceptions during httpRequest body deserialization.

### DIFF
--- a/src/Convey.WebApi/src/Convey.WebApi/Extensions.cs
+++ b/src/Convey.WebApi/src/Convey.WebApi/Extensions.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Open.Serialization.Json;
 
 namespace Convey.WebApi;
@@ -293,8 +294,11 @@ public static class Extensions
 
     public static async Task<T> ReadJsonAsync<T>(this HttpContext httpContext)
     {
+        var logger = httpContext.RequestServices.GetService<ILogger>();
+
         if (httpContext.Request.Body is null)
         {
+            logger?.LogError("Null request body received.");
             httpContext.Response.StatusCode = 400;
             await httpContext.Response.Body.WriteAsync(InvalidJsonRequestBytes, 0, InvalidJsonRequestBytes.Length);
 
@@ -336,8 +340,10 @@ public static class Extensions
 
             return default;
         }
-        catch
+        catch(Exception ex)
         {
+            logger?.LogError(ex, "Exception thrown while deserializing request.");
+
             httpContext.Response.StatusCode = 400;
             await httpContext.Response.Body.WriteAsync(InvalidJsonRequestBytes, 0, InvalidJsonRequestBytes.Length);
 


### PR DESCRIPTION
As stated in issue: #100 , exceptions during deserialization of payloads (HttpRequest body) are not logged. So debugging bugs in that code can be quite hit-and-miss.

Added logging (if ILogger is available in the request services) messages that will warn about a null body received and if an exception is thrown during the deserialization process.