### PR TITLE
Use custom JsonSerializerOptions on public contracts serialization

### DIFF
--- a/src/Convey.WebApi.CQRS/src/Convey.WebApi.CQRS/Extensions.cs
+++ b/src/Convey.WebApi.CQRS/src/Convey.WebApi.CQRS/Extensions.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading.Tasks;
 using Convey.CQRS.Commands;
 using Convey.CQRS.Queries;
 using Convey.WebApi.CQRS.Builders;
@@ -7,6 +5,9 @@ using Convey.WebApi.CQRS.Middlewares;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace Convey.WebApi.CQRS;
 
@@ -48,11 +49,17 @@ public static class Extensions
         bool attributeRequired, string endpoint = "/_contracts")
         => app.UsePublicContracts(endpoint, null, attributeRequired);
 
-    public static IApplicationBuilder UsePublicContracts(this IApplicationBuilder app,
-        string endpoint = "/_contracts", Type attributeType = null, bool attributeRequired = true)
-        => app.UseMiddleware<PublicContractsMiddleware>(string.IsNullOrWhiteSpace(endpoint) ? "/_contracts" :
-            endpoint.StartsWith("/") ? endpoint : $"/{endpoint}", attributeType ?? typeof(PublicContractAttribute),
-            attributeRequired);
+    public static IApplicationBuilder UsePublicContracts(
+        this IApplicationBuilder app,
+        string endpoint = "/_contracts",
+        Type attributeType = null,
+        bool attributeRequired = true,
+        JsonSerializerOptions jsonSerializerOptions = null)
+        => app.UseMiddleware<PublicContractsMiddleware>(
+            string.IsNullOrWhiteSpace(endpoint) ? "/_contracts" : endpoint.StartsWith("/") ? endpoint : $"/{endpoint}",
+            attributeType ?? typeof(PublicContractAttribute),
+            attributeRequired,
+            jsonSerializerOptions);
 
     public static Task SendAsync<T>(this HttpContext context, T command) where T : class, ICommand
         => context.RequestServices.GetRequiredService<ICommandDispatcher>().SendAsync(command);

--- a/src/Convey.WebApi.CQRS/src/Convey.WebApi.CQRS/Extensions.cs
+++ b/src/Convey.WebApi.CQRS/src/Convey.WebApi.CQRS/Extensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Convey.WebApi.CQRS;
@@ -59,7 +60,13 @@ public static class Extensions
             string.IsNullOrWhiteSpace(endpoint) ? "/_contracts" : endpoint.StartsWith("/") ? endpoint : $"/{endpoint}",
             attributeType ?? typeof(PublicContractAttribute),
             attributeRequired,
-            jsonSerializerOptions);
+            jsonSerializerOptions ?? new()
+            {
+                PropertyNameCaseInsensitive = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+                WriteIndented = true
+            });
 
     public static Task SendAsync<T>(this HttpContext context, T command) where T : class, ICommand
         => context.RequestServices.GetRequiredService<ICommandDispatcher>().SendAsync(command);


### PR DESCRIPTION
On public contracts serialization, support custom JsonSerializerOptions or use middleware's defaults.