### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Convey - a simple recipe for .NET Core microservices 
+
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/469/convey-microservices-net-core/badge)](https://builtwithdot.net/project/469/convey-microservices-net-core)
+
 ## Read the docs [here](https://convey-stack.github.io) or [see it in action](https://www.youtube.com/watch?v=cxEXx4UT1FI).
 
 


### PR DESCRIPTION
Since Convey Microservices is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for Convey Microservices to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)